### PR TITLE
Removing default for SDK config storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In Orchestrator:
   * Reset Key - Random text used to revoke the Secret Server SDK and reinitalize it.
   * Username Field Slug - The slug name of the Secret Template field that Orchestrator will pull the username from when retrieving an Asset from Secret Server.
   * Password Field Slug - The slug name of the Secret Tempalte field that Orchestrator will pull the password from when retrieving an Asset from Secret Server.
-  * SDK Config Storage Path - When initialized, the Secret Server SDK creates encrypted storage files. These by default are stored in the user's profile directory. If the orchestrator IIS App Pool is not set to Load User Profile, then that path is the Windows temp directory. If the IIS App Pool is set to Load User Profile, you can change this to the app pool identity's profile path. Or you create a custom path and grant permissions to the app pool identity.
+  * SDK Config Storage Path - When initialized, the Secret Server SDK creates encrypted storage files. Create a custom directory on the server and grant read / write permissions to the app pool identity.
 * Create an asset of type Credential and select the Secret Server Credential Store. For the External Name enter the Secret Id of an existing Secret you want to pull the username / password from.
   * When the asset is used in a robot process, it will pull the username and password from the Secret.
 * Create a robot and select the Secret Server Credential Store. Enter the username and use the Secret Id as the External Name.

--- a/SecretServer.SecureStore/SecretServerSecureStore.cs
+++ b/SecretServer.SecureStore/SecretServerSecureStore.cs
@@ -80,7 +80,7 @@ namespace SecretServer.SecureStore
                 {
                     Key = "SdkConfigDirectory",
                     DisplayName = "SDK Config Storage Path",
-                    DefaultValue = "c:\\windows\\temp",
+                    IsMandatory = true,
                 },
             };
         }


### PR DESCRIPTION
A custom path must now be created when setting up credential stores to avoid DPAPI permission issues when using windows temp.